### PR TITLE
Additional tests for $not and $nor

### DIFF
--- a/test/test.coffee
+++ b/test/test.coffee
@@ -251,6 +251,32 @@ describe "Underscore Query Tests", ->
     assert.equal result[0].title, "About"
 
 
+  it "$not operator", ->
+    a = create()
+    result = _.query a, {$not: {likes:  {$lt: 12}}}
+    assert.equal result.length, 2
+
+  #  These tests fail, but would pass if it $not worked parallel to MongoDB
+  #  it "$not operator", ->
+  #    a = create()
+  #    result = _.query a, {likes:  {$not: {$lt: 12}}}
+  #    assert.equal result.length, 2
+  #
+  #  it "$not operator", ->
+  #    a = create()
+  #    result = _.query a, likes: {$not:  12}
+  #    assert.equal result.length, 2
+  #
+  #  it "$not $equal operator", ->
+  #    a = create()
+  #    result = _.query a, likes: {$not:  {$equal: 12}}
+  #    assert.equal result.length, 2
+
+  #  it "$not $equal operator", ->
+  #    a = create()
+  #    result = _.query a, likes: {$not:  {ne: 12}}
+  #    assert.equal result.length, 1
+
 
 
   it "$elemMatch", ->
@@ -706,3 +732,35 @@ describe "Underscore Query Tests", ->
     a = create()
     result = _.query a, {likes:  {$not: {$lt: 12}}}
     assert.equal result.length, 2
+
+  # This is parallel to MongoDB
+  it "$not operator - mongo style", ->
+    a = create()
+    result = _.query a, {likes:  {$not: 12}}
+    assert.equal result.length, 2
+
+  it "combination of $gt and $lt - mongo style", ->
+    a = create()
+    result = _.query a, {likes: { $gt: 2, $lt: 20}}
+    assert.equal result.length, 1
+
+  it "$not combination of $gt and $lt  - mongo style", ->
+    a = create()
+    result = _.query a, {likes: {$not: { $gt: 2, $lt: 20}}}
+    assert.equal result.length, 2
+
+  it "$nor combination of $gt and $lt  - expressions ", ->
+    a = create()
+    result = _.query a, {$nor: [{likes: { $gt: 2}}, {likes: { $lt: 20}}]}
+    assert.equal result.length, 0
+
+#  This query is not a valid MongoDB query, but if it were one would expect it to yield an empty set
+#  it "$nor combination of $gt and $lt  - values", ->
+#    a = create()
+#    result = _.query a, {likes: {$nor: [{ $gt: 2}, {$lt: 20}]}}
+#    assert.equal result.length, 0
+
+  it "combination of $gt  and $not", ->
+    a = create()
+    result = _.query a, {likes: { $not: 2, $lt: 20}}
+    assert.equal result.length, 1

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -256,26 +256,26 @@ describe "Underscore Query Tests", ->
     result = _.query a, {$not: {likes:  {$lt: 12}}}
     assert.equal result.length, 2
 
-  #  These tests fail, but would pass if it $not worked parallel to MongoDB
-  #  it "$not operator", ->
-  #    a = create()
-  #    result = _.query a, {likes:  {$not: {$lt: 12}}}
-  #    assert.equal result.length, 2
-  #
-  #  it "$not operator", ->
-  #    a = create()
-  #    result = _.query a, likes: {$not:  12}
-  #    assert.equal result.length, 2
-  #
-  #  it "$not $equal operator", ->
-  #    a = create()
-  #    result = _.query a, likes: {$not:  {$equal: 12}}
-  #    assert.equal result.length, 2
+  #These tests fail, but would pass if it $not worked parallel to MongoDB
+  it "$not operator", ->
+    a = create()
+    result = _.query a, {likes:  {$not: {$lt: 12}}}
+    assert.equal result.length, 2
 
-  #  it "$not $equal operator", ->
-  #    a = create()
-  #    result = _.query a, likes: {$not:  {ne: 12}}
-  #    assert.equal result.length, 1
+  it "$not operator", ->
+    a = create()
+    result = _.query a, likes: {$not:  12}
+    assert.equal result.length, 2
+
+  it "$not $equal operator", ->
+    a = create()
+    result = _.query a, likes: {$not:  {$equal: 12}}
+    assert.equal result.length, 2
+
+  it "$not $equal operator", ->
+    a = create()
+    result = _.query a, likes: {$not:  {$ne: 12}}
+    assert.equal result.length, 1
 
 
 


### PR DESCRIPTION
Added additional tests, uncommenting those added in prior discussion (these all pass) and adding additional ones.  

There's one extra test commented out below.  This fails, as I think it should, as it's not a parallel construct to MongoDB.   I'm not sure how test that it fails, as it could fail in so many ways.  Here it just returns all the records, but there could be other valid responses to an invalid constraint.

```coffeescript
#  This query is not a valid MongoDB query, but if it were one would expect it to yield an empty set
#  it "$nor combination of $gt and $lt  - values", ->
#    a = create()
#    result = _.query a, {likes: {$nor: [{ $gt: 2}, {$lt: 20}]}}
#    assert.equal result.length, 0
```