### PR TITLE
Restrict lodash dep to 3.x as we do not support lodash 4 api

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "backbone":"",
         "uglify-js": "",
         "handlebars": "",
-        "lodash":""
+        "lodash":"3.x"
     },
     "scripts": {
         "test": "mocha"


### PR DESCRIPTION
`detect` and others aliases are not in lodash 4, only lodash 3