### PR TITLE
Add support for dynamic function queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ In updating the prokect serveral new features have been added, including the abi
  - Accepts dot notation to query deep properties (e.g. {"stats.views.december": 100}
  - Custom getters can be defined, (e.g. `.get` for Backbone)
  - Works well with underscore chaining
+ - Dynamically evaluates functions on query
 
 Please report any bugs, feature requests in the issue tracker.
 Pull requests are welcome!
@@ -184,9 +185,9 @@ _.query( MyCollection, { title: {$ne:"Test"} });
 These conditional operators can be used for greater than and less than comparisons in queries
 
 ```js
-_.query( MyCollection, { likes: {$lt:10} });
+_.query( MyCollection, { likes: {$lt: () -> 10} });
 // Returns all models which have a "likes" attribute of less than 10
-_.query( MyCollection, { likes: {$lte:10} });
+_.query( MyCollection, { likes: {$lte: () -> 10} });
 // Returns all models which have a "likes" attribute of less than or equal to 10
 _.query( MyCollection, { likes: {$gt:10} });
 // Returns all models which have a "likes" attribute of greater than 10

--- a/test/suite.coffee
+++ b/test/suite.coffee
@@ -201,6 +201,23 @@ module.exports = (_query) ->
     assert.equal result.length, 1
     assert.equal result[0].title, "Home"
 
+  it "Dynamic equals query", ->
+    a = create()
+    result = _query a, title:()->"Homes"
+    assert.equal result.length, 0
+    result = _query a, title:()->"Home"
+    assert.equal result.length, 1
+
+  it "ensure dynamic query not cached", ->
+    a = create()
+    count = 12 - a.length
+    query = _query.testWith(likes: $lt: -> count += 1)
+
+    result = _.filter(a, query)
+    assert.equal (result).length, 1
+    result = _.filter(a, query)
+    assert.equal (result).length, 2
+
   it "$and operator", ->
     a = create()
     result = _query a, likes: {$gt: 5}, colors: {$contains: "yellow"}


### PR DESCRIPTION
We have an extremely common use case at majik to make queries like


```js

let query = _query.testWith({
   startTime: $gt: -> moment(),
   endTime: $lt: -> moment().add(1, 'day')
})
```

Such that we would like the value of the query to be dynamically evaluated. We were previously just recursively updating the query before the `testWith` whenever a query would be run but this was a significant bottleneck in our applications performance.