### PR TITLE
support $regex  string + $options

### DIFF
--- a/src/underscore-query.coffee
+++ b/src/underscore-query.coffee
@@ -59,11 +59,7 @@ utils.makeGetter = (keys) ->
 
 multipleConditions = (key, queries) ->
   (for type, val of queries
-    if type == '$options' then continue
-    (o = {})[type] = val
-    o.$options = queries.$options if '$options' of queries
-    utils.makeObj key, o
-  )
+    utils.makeObj key, utils.makeObj(type, val))
 
 parseParamType = (query) ->
   result = []
@@ -101,7 +97,9 @@ parseParamType = (query) ->
         # Otherwise extract the key and value
         else
           for own type, value of queryParam
-            if type == "$options" then continue
+            if type == "$options"
+              if "$regex" of queryParam or "regexp" of queryParam then continue
+              throw new Error("$options needs a $regex")
             # Before adding the query, its value is checked to make sure it is the right type
             if testQueryValue type, value
               o.type = type

--- a/test/suite.coffee
+++ b/test/suite.coffee
@@ -268,6 +268,12 @@ module.exports = (_query) ->
     result = _query a, content: {$regex: 'dummy', $options: 'i'}
     assert.equal result.length, 3
 
+  it "$options errors without regexp", ->
+    a = create()
+    assert.throws(-> 
+      result = _query a, content: {$options: 'i'}
+    )
+
   it "$cb - callback", ->
     a = create()
     fn = (attr) ->

--- a/test/suite.coffee
+++ b/test/suite.coffee
@@ -258,6 +258,16 @@ module.exports = (_query) ->
     result = _query a, content: /javascript/i
     assert.equal result.length, 1
 
+  it "$regex with object", ->
+    a = create()
+    result = _query a, content: {$regex: 'dummy'}
+    assert.equal result.length, 1
+
+  it "$regex with object+options", ->
+    a = create()
+    result = _query a, content: {$regex: 'dummy', $options: 'i'}
+    assert.equal result.length, 3
+
   it "$cb - callback", ->
     a = create()
     fn = (attr) ->


### PR DESCRIPTION
Not the prettiest change, but it fixes #25 to enable support for regex objects with options.

/cc @davidgtonge 