### PR TITLE
update to use coffeescript 2

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -5,7 +5,7 @@
 fs               = require 'fs'
 path             = require 'path'
 {spawn, exec}    = require 'child_process'
-CoffeeScript     = require 'coffee-script'
+CoffeeScript     = require 'coffeescript'
 handlebars       = require "handlebars"
 uglify = require 'uglify-js'
 wrapper = handlebars.compile fs.readFileSync("build/wrapper.js").toString()

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "coffee-script": ">=1.7.x",
-    "mocha": "",
     "backbone": "",
-    "uglify-js": "",
+    "coffeescript": "^2.3.1",
     "handlebars": "",
     "lodash": "3.x",
+    "mocha": "",
+    "uglify-js": "",
     "underscore": ">=1.6.x"
   },
   "scripts": {

--- a/test/blank.coffee
+++ b/test/blank.coffee
@@ -1,5 +1,4 @@
 # Requires
-require "coffee-script"
 assert = require('assert')
 _ = require "underscore"
 require("../src/underscore-query")(_)

--- a/test/lodash.coffee
+++ b/test/lodash.coffee
@@ -1,6 +1,4 @@
 # Requires
-require "coffee-script"
-
 assert = require "assert"
 _ = require "lodash"
 require("../src/underscore-query")(_)

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
 --reporter spec
 --ui bdd
 --bail
---compilers coffee:coffee-script/register
+--compilers coffee:coffeescript/register

--- a/test/suite.coffee
+++ b/test/suite.coffee
@@ -1,4 +1,3 @@
-require "coffee-script"
 assert = require "assert"
 _ = require "underscore"
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1,6 +1,4 @@
 # Requires
-require "coffee-script"
-
 assert = require "assert"
 _ = require "underscore"
 require("../src/underscore-query")(_)


### PR DESCRIPTION
These changes are to make underscore-query depend on Coffeescript 2 rather than Coffeescript 1.

Separately, mocha's `--compilers coffee:coffeescript/register` needs to be updated in `test/mocha.opts`

I'm not a mocha person and I'm still researching that.  It currently works with a deprecation warning.